### PR TITLE
feat: add free-cursor option for unconstrained cursor during drag-scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Details:
   (plasmashell, xfdesktop, waybar, GNOME Shell, ...) is focused midscroll
   pauses, so a middle-drag can't hijack the desktop. Turn on **Enable on
   desktop & panels** (`DESKTOP_SCROLL = true`) if you want it there too.
+- By default the cursor is anchored at the press point during a drag-scroll.
+  Turn on **free cursor** (`FREE_CURSOR = true`) to let it follow the hand
+  instead — useful if you dislike the locked feel, but note the scroll jumps
+  to whatever window is under the cursor once it leaves the original one.
 
 ## Install
 
@@ -100,6 +104,7 @@ TICK_HZ = 90              # scroll event rate (higher = smoother)
 NATURAL = false           # true = inverted / touchscreen-style direction
 TOGGLE_MODE = false       # true = click to start/stop instead of hold-drag
 DESKTOP_SCROLL = false    # true = also autoscroll over the desktop and panels
+FREE_CURSOR = false       # true = cursor moves freely during drag-scroll
 BLACKLIST = freecad, orcaslicer, minecraft
                           # window-class substrings that pause midscroll
                           # (apps with native middle-drag); '' disables
@@ -120,8 +125,8 @@ midscroll --help          # full option list
 
 `--debug` turns on debug logging (device probing, focus changes, scroll
 starts); `--blacklist "app1, app2"`, `--natural` / `--no-natural`,
-`--toggle-mode` / `--no-toggle-mode` and `--desktop` / `--no-desktop`
-(autoscroll over the desktop and panels) toggle the corresponding behaviors.
+`--toggle-mode` / `--no-toggle-mode` and `--desktop` / `--no-desktop`, `--free-cursor` / `--no-free-cursor`
+(autoscroll over the desktop and panels, and free-cursor mode) toggle the corresponding behaviors.
 
 ## Pause / uninstall
 

--- a/midscroll-apply.py
+++ b/midscroll-apply.py
@@ -32,7 +32,7 @@ FLOATS = {
     "MAX_DRAG_PX": True,
     "TICK_HZ": True,
 }
-BOOLS = ("NATURAL", "TOGGLE_MODE", "DESKTOP_SCROLL")
+BOOLS = ("NATURAL", "TOGGLE_MODE", "DESKTOP_SCROLL", "FREE_CURSOR")
 KEYS = tuple(FLOATS) + BOOLS + ("BLACKLIST",)
 
 # Defaults for any key the caller omits.
@@ -40,7 +40,7 @@ DEFAULTS = {
     "DEADZONE_PX": 15.0, "SPEED_MULT": 0.008, "SPEED_EXP": 2.2,
     "MAX_PX_PER_SEC": 30000.0, "PX_PER_NOTCH": 55.0, "MAX_DRAG_PX": 1200.0,
     "TICK_HZ": 90.0, "NATURAL": False, "TOGGLE_MODE": False,
-    "DESKTOP_SCROLL": False,
+    "DESKTOP_SCROLL": False, "FREE_CURSOR": False,
     "BLACKLIST": "freecad, orcaslicer, minecraft",
 }
 
@@ -67,6 +67,12 @@ TOGGLE_MODE = {TOGGLE_MODE}
 # Autoscroll over the desktop and panels too. Off by default, so a middle-drag
 # on the desktop/taskbar (plasmashell, xfdesktop, waybar, ...) is left alone.
 DESKTOP_SCROLL = {DESKTOP_SCROLL}
+
+# Let the cursor move freely during a drag-scroll. Off by default: the cursor
+# is anchored so the scroll stays on the window you started in. With this on
+# the cursor follows the hand, but once it leaves the original window the
+# scroll jumps to whatever is under it.
+FREE_CURSOR = {FREE_CURSOR}
 
 # Apps that use middle-drag themselves: while one of these is the focused
 # window, midscroll pauses. Comma-separated, case-insensitive window-class
@@ -133,6 +139,7 @@ def main(argv):
         NATURAL="true" if values["NATURAL"] else "false",
         TOGGLE_MODE="true" if values["TOGGLE_MODE"] else "false",
         DESKTOP_SCROLL="true" if values["DESKTOP_SCROLL"] else "false",
+        FREE_CURSOR="true" if values["FREE_CURSOR"] else "false",
         BLACKLIST=values["BLACKLIST"],
         **{k: values[k] for k in FLOATS},
     )

--- a/midscroll-settings.py
+++ b/midscroll-settings.py
@@ -37,12 +37,16 @@ BOOLS = [
     ("DESKTOP_SCROLL", "Enable on desktop & panels",
      "Allow autoscroll while the desktop or a panel/taskbar is focused. "
      "Off by default so a middle-drag doesn't hijack the desktop."),
+    ("FREE_CURSOR", "Free cursor during drag",
+     "Let the cursor move freely while drag-scrolling instead of anchoring "
+     "it. Note: once the cursor leaves the window you started in, the "
+     "scroll jumps to whatever is under it."),
 ]
 DEFAULTS = {
     "DEADZONE_PX": 15.0, "SPEED_MULT": 0.008, "SPEED_EXP": 2.2,
     "MAX_PX_PER_SEC": 30000.0, "PX_PER_NOTCH": 55.0, "MAX_DRAG_PX": 1200.0,
     "TICK_HZ": 90.0, "NATURAL": False, "TOGGLE_MODE": False,
-    "DESKTOP_SCROLL": False,
+    "DESKTOP_SCROLL": False, "FREE_CURSOR": False,
     "BLACKLIST": "freecad, orcaslicer, minecraft",
 }
 FLOAT_KEYS = [f[0] for f in FLOATS]

--- a/midscroll.conf
+++ b/midscroll.conf
@@ -29,6 +29,12 @@ TOGGLE_MODE = false
 # so a middle-drag there doesn't hijack the desktop. Set true to allow it.
 DESKTOP_SCROLL = false
 
+# Let the cursor move freely during a drag-scroll. Off by default: the cursor
+# is anchored so the scroll stays on the window you started in. With this on
+# the cursor follows the hand, but once it leaves the original window the
+# scroll jumps to whatever is under it.
+FREE_CURSOR = false
+
 # Apps that use middle-drag themselves: while one of these is the focused
 # window, midscroll pauses and the middle button behaves natively.
 # Comma-separated, case-insensitive window-class substrings; leave empty

--- a/midscroll.py
+++ b/midscroll.py
@@ -57,6 +57,7 @@ TICK_HZ = 90.0            # scroll event rate (higher = smoother)
 NATURAL = False           # True inverts scroll direction
 TOGGLE_MODE = False       # True: click to start/stop instead of hold-and-drag
 DESKTOP_SCROLL = False    # True: also autoscroll over the desktop and panels
+FREE_CURSOR = False       # True lets the cursor move freely during a drag-scroll
 
 # Window-class substrings (case-insensitive) over which midscroll pauses
 # and the middle button behaves natively.
@@ -78,7 +79,7 @@ SOCK_PATH = SOCK_DIR + "/state.sock"
 
 FLOAT_KEYS = {"DEADZONE_PX", "TICK_HZ", "SPEED_MULT", "SPEED_EXP",
               "MAX_PX_PER_SEC", "PX_PER_NOTCH", "MAX_DRAG_PX"}
-BOOL_KEYS = {"NATURAL", "TOGGLE_MODE", "DESKTOP_SCROLL"}
+BOOL_KEYS = {"NATURAL", "TOGGLE_MODE", "DESKTOP_SCROLL", "FREE_CURSOR"}
 # Zero would divide by zero (TICK_HZ, PX_PER_NOTCH) or make the daemon
 # silently never scroll; only the dead zone may be zero.
 POSITIVE_KEYS = FLOAT_KEYS - {"DEADZONE_PX"}
@@ -602,7 +603,8 @@ async def pump(path, dev, states, tasks, focus, our_paths):
                     # hitting the original window instead of whatever the
                     # cursor would have drifted over.
                     _accumulate(st, ev)
-                    continue
+                    if not FREE_CURSOR:
+                        continue
             if ev.type == e.EV_SYN:
                 if ev.code == e.SYN_DROPPED:
                     _resync(ui, dev, held, st)
@@ -756,6 +758,10 @@ def parse_args(argv=None):
                    default=None, dest="desktop_scroll",
                    help="also autoscroll over the desktop and panels "
                         "(default: off, so they are left alone)")
+    p.add_argument("--free-cursor", action=argparse.BooleanOptionalAction,
+                   default=None,
+                   help="let the cursor move freely during drag-scroll "
+                        "instead of anchoring it")
     p.add_argument("--blacklist", metavar="APPS", default=None,
                    help="comma-separated window-class substrings over which "
                         "midscroll pauses (default: "
@@ -783,12 +789,14 @@ def cli():
         globals()["TOGGLE_MODE"] = args.toggle_mode
     if args.desktop_scroll is not None:
         globals()["DESKTOP_SCROLL"] = args.desktop_scroll
+    if args.free_cursor is not None:
+        globals()["FREE_CURSOR"] = args.free_cursor
     if args.blacklist is not None:
         globals()["BLACKLIST"] = parse_blacklist(args.blacklist)
-    log.debug("tunables: %s NATURAL=%s TOGGLE_MODE=%s DESKTOP_SCROLL=%s "
+    log.debug("tunables: %s NATURAL=%s TOGGLE_MODE=%s DESKTOP_SCROLL=%s FREE_CURSOR=%s "
               "BLACKLIST=%s",
               " ".join(f"{k}={globals()[k]:g}" for k in sorted(FLOAT_KEYS)),
-              NATURAL, TOGGLE_MODE, DESKTOP_SCROLL, BLACKLIST)
+              NATURAL, TOGGLE_MODE, DESKTOP_SCROLL, FREE_CURSOR, BLACKLIST)
     asyncio.run(main())
 
 


### PR DESCRIPTION
Add FREE_CURSOR config option and --free-cursor/--no-free-cursor CLI flag. When enabled, mouse motion is forwarded to the desktop during a drag-scroll instead of being swallowed to anchor the cursor. The drag offset is still accumulated for the speed calculation and clamped to MAX_DRAG_PX, so speed behavior is unchanged — only the cursor is no longer locked.

Default remains false (anchored cursor).