### PR TITLE
Preserve quick middle clicks in toggle mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ normal middle click (paste, open link in new tab). Diagonal drags scroll
 both axes, so it pans wide pages too.
 
 Prefer clicking to holding? Turn on **toggle mode** (in the settings GUI or
-`TOGGLE_MODE = true`) for the Windows-Explorer / Firefox style instead: one
+`TOGGLE_MODE = true`) for the Windows-Explorer / Firefox style instead: a
 middle click starts autoscroll, the cursor moves freely, and any click
-stops it.
+stops it. Set `TOGGLE_HOLD_MS` above zero to preserve quick middle-click
+actions such as opening and closing browser tabs; a longer press then
+starts autoscroll.
 
 It works in every app, on Wayland and X11, because it operates at the
 kernel input layer (evdev in, uinput out) instead of hooking any
@@ -106,6 +108,7 @@ PX_PER_NOTCH = 55         # px one wheel notch scrolls in your apps
 TICK_HZ = 90              # scroll event rate (higher = smoother)
 NATURAL = false           # true = inverted / touchscreen-style direction
 TOGGLE_MODE = false       # true = click to start/stop instead of hold-drag
+TOGGLE_HOLD_MS = 0        # >0 = quick clicks stay native; hold to autoscroll
 DESKTOP_SCROLL = false    # true = also autoscroll over the desktop and panels
 GHOST_CURSOR = true       # draw a cursor that follows your hand while dragging
 GHOST_SCALE = 1.0         # how far it travels per unit of mouse motion
@@ -133,8 +136,9 @@ midscroll --help          # full option list
 starts); `--blacklist "app1, app2"`, `--natural` / `--no-natural`,
 `--toggle-mode` / `--no-toggle-mode`, `--desktop` / `--no-desktop`
 (autoscroll over the desktop and panels) and `--ghost-cursor` /
-`--no-ghost-cursor` toggle the corresponding behaviors. `--list-devices`
-prints the device list and exits.
+`--no-ghost-cursor` toggle the corresponding behaviors.
+`--toggle-hold-ms N` preserves quick middle-clicks while toggle mode is on.
+`--list-devices` prints the device list and exits.
 
 ### Choosing which mice to use
 

--- a/midscroll-apply.py
+++ b/midscroll-apply.py
@@ -48,6 +48,7 @@ FLOATS = {
     "MAX_DRAG_PX": True,
     "TICK_HZ": True,
     "GHOST_SCALE": True,
+    "TOGGLE_HOLD_MS": False,
 }
 BOOLS = ("NATURAL", "TOGGLE_MODE", "DESKTOP_SCROLL", "GHOST_CURSOR")
 DEVICES = ("EXTRA_DEVICES", "IGNORE_DEVICES")
@@ -57,7 +58,8 @@ KEYS = tuple(FLOATS) + BOOLS + DEVICES + ("BLACKLIST",)
 DEFAULTS = {
     "DEADZONE_PX": 15.0, "SPEED_MULT": 0.008, "SPEED_EXP": 2.2,
     "MAX_PX_PER_SEC": 30000.0, "PX_PER_NOTCH": 55.0, "MAX_DRAG_PX": 1200.0,
-    "TICK_HZ": 90.0, "GHOST_SCALE": 1.0, "NATURAL": False,
+    "TICK_HZ": 90.0, "GHOST_SCALE": 1.0, "TOGGLE_HOLD_MS": 0.0,
+    "NATURAL": False,
     "TOGGLE_MODE": False, "DESKTOP_SCROLL": False, "GHOST_CURSOR": True,
     "BLACKLIST": "freecad, orcaslicer, minecraft",
     "EXTRA_DEVICES": "", "IGNORE_DEVICES": "",
@@ -81,7 +83,9 @@ NATURAL = {NATURAL}           # true = inverted / touchscreen-style direction
 
 # Click the middle button once to start autoscroll and again (or any click)
 # to stop, Windows-Explorer style, instead of holding it and dragging.
+# Set TOGGLE_HOLD_MS above zero to keep quick presses as native middle clicks.
 TOGGLE_MODE = {TOGGLE_MODE}
+TOGGLE_HOLD_MS = {TOGGLE_HOLD_MS:g}
 
 # Autoscroll over the desktop and panels too. Off by default, so a middle-drag
 # on the desktop/taskbar (plasmashell, xfdesktop, waybar, ...) is left alone.

--- a/midscroll-settings.py
+++ b/midscroll-settings.py
@@ -48,12 +48,13 @@ FLOATS = [
     ("MAX_DRAG_PX", "Max drag distance (px)", 100, 10000, 10, 0),
     ("TICK_HZ", "Event rate (Hz)", 10, 360, 5, 0),
     ("GHOST_SCALE", "Ghost cursor travel", 0.1, 5.0, 0.1, 1),
+    ("TOGGLE_HOLD_MS", "Toggle hold threshold (ms)", 0, 1000, 10, 0),
 ]
 # key, label, subtitle
 BOOLS = [
     ("TOGGLE_MODE", "Toggle mode",
-     "Click the middle button to start autoscroll and again to stop, "
-     "instead of holding and dragging."),
+     "Start autoscroll without holding throughout; any click stops it. "
+     "Set a hold threshold below to preserve quick middle-clicks."),
     ("NATURAL", "Natural scrolling", "Invert the scroll direction."),
     ("GHOST_CURSOR", "Ghost cursor",
      "While you drag, draw a cursor that follows your hand from the "
@@ -66,7 +67,8 @@ BOOLS = [
 DEFAULTS = {
     "DEADZONE_PX": 15.0, "SPEED_MULT": 0.008, "SPEED_EXP": 2.2,
     "MAX_PX_PER_SEC": 30000.0, "PX_PER_NOTCH": 55.0, "MAX_DRAG_PX": 1200.0,
-    "TICK_HZ": 90.0, "GHOST_SCALE": 1.0, "NATURAL": False,
+    "TICK_HZ": 90.0, "GHOST_SCALE": 1.0, "TOGGLE_HOLD_MS": 0.0,
+    "NATURAL": False,
     "TOGGLE_MODE": False, "DESKTOP_SCROLL": False, "GHOST_CURSOR": True,
     "BLACKLIST": "freecad, orcaslicer, minecraft",
     "EXTRA_DEVICES": "", "IGNORE_DEVICES": "",

--- a/midscroll.conf
+++ b/midscroll.conf
@@ -20,8 +20,11 @@ NATURAL = false           # true = inverted / touchscreen-style direction
 
 # Click the middle button once to start autoscroll and again (or any click)
 # to stop, Windows-Explorer / Firefox style, instead of holding and
-# dragging. In this mode the middle button no longer pastes.
+# dragging. Set TOGGLE_HOLD_MS above zero to keep quick presses as native
+# middle clicks and require a longer press to start autoscroll. Zero retains
+# the traditional click-to-toggle behavior.
 TOGGLE_MODE = false
+TOGGLE_HOLD_MS = 0
 
 # Autoscroll over the desktop and panels too. Off by default: while the
 # desktop or a panel/taskbar is focused (plasmashell, nemo-desktop,

--- a/midscroll.py
+++ b/midscroll.py
@@ -7,9 +7,10 @@ scrolls. Release to stop. A quick middle click without dragging passes
 through as a normal middle click (paste / open link in new tab).
 
 With TOGGLE_MODE enabled the interaction is instead the Windows-Explorer /
-Firefox style: a single middle click starts autoscroll, the cursor then
-moves freely and the page scrolls by its distance from that origin, and any
-mouse click stops it. (In that mode the middle button no longer pastes.)
+Firefox style: a middle click starts autoscroll, the cursor then moves
+freely and the page scrolls by its distance from that origin, and any mouse
+click stops it. Set TOGGLE_HOLD_MS above zero to reserve quick presses for
+native middle clicks and start autoscroll only after a longer press.
 
 Works on Wayland and X11 in any application, because it sits at the kernel
 input layer: it grabs the real mouse and re-emits its events through a
@@ -65,6 +66,7 @@ MAX_DRAG_PX = 1200.0      # cap on effective drag distance (~screen height)
 TICK_HZ = 90.0            # scroll event rate (higher = smoother)
 NATURAL = False           # True inverts scroll direction
 TOGGLE_MODE = False       # True: click to start/stop instead of hold-and-drag
+TOGGLE_HOLD_MS = 0.0      # reserve shorter toggle-mode presses as native clicks
 DESKTOP_SCROLL = False    # True: also autoscroll over the desktop and panels
 GHOST_CURSOR = True       # True: helper draws a cursor at the dragged point
 GHOST_SCALE = 1.0         # ghost travel per unit of mouse motion
@@ -119,13 +121,14 @@ WRITE_SKIP_BYTES = 4096    # skip updates for a client this far behind
 WRITE_DROP_BYTES = 65536   # disconnect a client this far behind
 
 FLOAT_KEYS = {"DEADZONE_PX", "TICK_HZ", "SPEED_MULT", "SPEED_EXP",
-              "MAX_PX_PER_SEC", "PX_PER_NOTCH", "MAX_DRAG_PX", "GHOST_SCALE"}
+              "MAX_PX_PER_SEC", "PX_PER_NOTCH", "MAX_DRAG_PX", "GHOST_SCALE",
+              "TOGGLE_HOLD_MS"}
 BOOL_KEYS = {"NATURAL", "TOGGLE_MODE", "DESKTOP_SCROLL", "GHOST_CURSOR",
              "ALLOW_KEYBOARDS"}
 DEVICE_KEYS = {"EXTRA_DEVICES", "IGNORE_DEVICES"}
 # Zero would divide by zero (TICK_HZ, PX_PER_NOTCH) or make the daemon
-# silently never scroll; only the dead zone may be zero.
-POSITIVE_KEYS = FLOAT_KEYS - {"DEADZONE_PX"}
+# silently never scroll; only the dead zone and optional hold time may be zero.
+POSITIVE_KEYS = FLOAT_KEYS - {"DEADZONE_PX", "TOGGLE_HOLD_MS"}
 
 # A device spec written as vendor:product, both hex.
 VID_PID_RE = re.compile(r"^[0-9a-fA-F]{1,4}:[0-9a-fA-F]{1,4}$")
@@ -495,6 +498,7 @@ class State:
         self.toggled = False      # toggle-mode scrolling (no button held)
         self.passthrough = False  # middle held over a blacklisted app
         self.eat_release = None   # button whose release to swallow (toggle)
+        self.middle_down_at = None  # monotonic time of toggle-mode press
         self.dx = 0.0             # cursor offset from the origin
         self.dy = 0.0
         self.acc_v = 0.0          # fractional hi-res units carried over
@@ -709,9 +713,10 @@ def phys_roundtrips():
 def _toggle_key(ev, st, ui, focus):
     """Handle a mouse-button event in toggle mode.
 
-    Windows-Explorer style: a middle click starts autoscroll, then any
-    click stops it. Returns True if the event was consumed (swallowed),
-    False if it should be forwarded like a normal button press.
+    A quick middle click is replayed natively, preserving browser tab-close
+    and open-link behavior. Holding it for TOGGLE_HOLD_MS starts autoscroll;
+    any later click stops it. Returns True if the event was consumed
+    (swallowed), False if it should be forwarded like a normal button press.
     """
     code = ev.code
     # Finish swallowing the click that stopped autoscroll: eat its release
@@ -736,15 +741,31 @@ def _toggle_key(ev, st, ui, focus):
                 ui.syn()
             else:
                 st.pending = True
+                st.middle_down_at = time.monotonic()
         elif ev.value == 0:
             if st.passthrough:
                 st.passthrough = False
                 ui.write(e.EV_KEY, e.BTN_MIDDLE, 0)
                 ui.syn()
             elif st.pending:
+                pressed_at = (
+                    st.middle_down_at
+                    if st.middle_down_at is not None
+                    else time.monotonic()
+                )
+                held_ms = (time.monotonic() - pressed_at) * 1000.0
                 st.pending = False
-                st.begin_toggle()
-                log.debug("toggle scroll started")
+                st.middle_down_at = None
+                if held_ms < TOGGLE_HOLD_MS:
+                    st.reset()
+                    ui.write(e.EV_KEY, e.BTN_MIDDLE, 1)
+                    ui.syn()
+                    ui.write(e.EV_KEY, e.BTN_MIDDLE, 0)
+                    ui.syn()
+                    log.debug("quick middle click passed through")
+                else:
+                    st.begin_toggle()
+                    log.debug("toggle scroll started")
         return True
     return False  # other buttons while idle pass straight through
 
@@ -1080,6 +1101,8 @@ CLI_FLOATS = {
     "--tick-hz": ("TICK_HZ", "scroll event rate"),
     "--ghost-scale": ("GHOST_SCALE",
                       "ghost-cursor travel per unit of mouse motion"),
+    "--toggle-hold-ms": ("TOGGLE_HOLD_MS",
+                         "minimum middle-button hold to start toggle mode"),
 }
 
 

--- a/tests/test_toggle_behavior.py
+++ b/tests/test_toggle_behavior.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Behavior checks for toggle mode's optional hold threshold."""
+
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def load_midscroll():
+    codes = {
+        name: value
+        for value, name in enumerate(
+            (
+                "ABS_MT_POSITION_X", "ABS_X", "BTN_JOYSTICK", "BTN_MIDDLE",
+                "BTN_MOUSE", "EV_ABS", "EV_KEY", "EV_REL", "EV_SYN",
+                "KEY_A", "KEY_ENTER", "KEY_SPACE", "KEY_Z", "REL_HWHEEL",
+                "REL_HWHEEL_HI_RES", "REL_WHEEL", "REL_WHEEL_HI_RES",
+                "REL_X", "REL_Y", "SYN_DROPPED",
+            ),
+            start=1,
+        )
+    }
+    fake_evdev = types.ModuleType("evdev")
+    fake_evdev.InputDevice = object
+    fake_evdev.UInput = object
+    fake_evdev.ecodes = SimpleNamespace(**codes)
+    fake_evdev.list_devices = lambda: []
+    sys.modules["evdev"] = fake_evdev
+
+    path = pathlib.Path(__file__).parents[1] / "midscroll.py"
+    spec = importlib.util.spec_from_file_location("midscroll_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeUInput:
+    def __init__(self):
+        self.events = []
+
+    def write(self, event_type, code, value):
+        self.events.append(("write", event_type, code, value))
+
+    def syn(self):
+        self.events.append(("syn",))
+
+
+class ToggleBehaviorTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.midscroll = load_midscroll()
+
+    def event(self, value):
+        return SimpleNamespace(code=self.midscroll.e.BTN_MIDDLE, value=value)
+
+    def run_press(self, threshold, press_time, release_time):
+        m = self.midscroll
+        m.TOGGLE_HOLD_MS = threshold
+        ui = FakeUInput()
+        state = m.State(ui)
+        focus = SimpleNamespace(blocked=False)
+        with patch.object(
+            m.time, "monotonic", side_effect=(press_time, release_time)
+        ):
+            m._toggle_key(self.event(1), state, ui, focus)
+            m._toggle_key(self.event(0), state, ui, focus)
+        return state, ui
+
+    def test_quick_middle_click_is_replayed_natively(self):
+        m = self.midscroll
+        state, ui = self.run_press(180, 10.0, 10.1)
+        self.assertFalse(state.toggled)
+        self.assertEqual(
+            ui.events,
+            [
+                ("write", m.e.EV_KEY, m.e.BTN_MIDDLE, 1),
+                ("syn",),
+                ("write", m.e.EV_KEY, m.e.BTN_MIDDLE, 0),
+                ("syn",),
+            ],
+        )
+
+    def test_long_middle_press_starts_toggle_scroll(self):
+        state, ui = self.run_press(180, 20.0, 20.25)
+        self.assertTrue(state.toggled)
+        self.assertEqual(ui.events, [])
+
+    def test_zero_threshold_retains_click_to_toggle(self):
+        state, ui = self.run_press(0, 30.0, 30.0)
+        self.assertTrue(state.toggled)
+        self.assertEqual(ui.events, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I use toggle mode, but noticed that it takes over every middle click. That means I can't middle-click links or close browser tabs normally.

This adds a `TOGGLE_HOLD_MS` setting. When it is set above zero, a quick middle-click is passed through normally and holding the button for the configured time starts autoscroll. The default is zero, so existing users keep the current click-to-toggle behavior.

I also added the setting to the config file, command line, settings window, and `midscroll-apply`. There are tests for quick clicks, held clicks, and the default zero-threshold behavior.

I tested it with a 180 ms threshold on Fedora 44 / GNOME 50 using a Logitech G305, and ran `python3 -m unittest discover -s tests -v`.

This came from my Fedora/GNOME companion project: https://github.com/oriraz1607/midscroll-gnome-indicator. I'm sending the reusable part upstream instead of keeping it only as a local patch. Some of the code was written with OpenAI Codex assistance; I reviewed and tested it before opening this PR.