### PR TITLE
metainfo: add <icon>

### DIFF
--- a/io.github.gnhen.midscroll.Settings.metainfo.xml
+++ b/io.github.gnhen.midscroll.Settings.metainfo.xml
@@ -11,6 +11,7 @@
   <developer id="io.github.gnhen">
     <name>gnhen</name>
   </developer>
+  <icon>midscroll</icon>
 
   <description>
     <p>


### PR DESCRIPTION
This adds the `<icon>` tag to the metainfo, using the same icon name as the `.desktop` file.